### PR TITLE
Fix bug in namespace joining

### DIFF
--- a/go/pkg/nrpc/options.go
+++ b/go/pkg/nrpc/options.go
@@ -133,13 +133,13 @@ func Namespace(ns string) Option {
 	return newOpt(
 		func(o *ServerOptions) error {
 			if ns != "" {
-				o.Namespace = strings.Trim(ns, ".") + "."
+				o.Namespace = strings.Trim(ns, ".")
 			}
 			return nil
 		},
 		func(o *ClientOptions) error {
 			if ns != "" {
-				o.Namespace = strings.Trim(ns, ".") + "."
+				o.Namespace = strings.Trim(ns, ".")
 			}
 			return nil
 		},


### PR DESCRIPTION
Removes an extra '.' that was being added to the namespace prefix. Now, when formatting a namespace/endpoint combination, the namespace and endpoint will be joined with a single '.'.